### PR TITLE
Dev/various fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,16 @@
 
 Welcome to Gpubsubbeat.
 
+This is a beat which pulls Google Cloud Stackdriver logging via exported pubsub.
+
 Ensure that this folder is at the following location:
-`${GOPATH}/github.com/nugielim/gpubsubbeat`
+`${GOPATH}/src/github.com/nugielim/gpubsubbeat`
 
 ## Getting Started with Gpubsubbeat
 
 ### Requirements
 
-* [Golang](https://golang.org/dl/) 1.7
+* [Golang](https://golang.org/dl/) 1.8+
 
 ### Init Project
 To get running with Gpubsubbeat and also install the
@@ -99,9 +101,9 @@ make clean
 To clone Gpubsubbeat from the git repository, run the following commands:
 
 ```
-mkdir -p ${GOPATH}/github.com/nugielim/gpubsubbeat
-cd ${GOPATH}/github.com/nugielim/gpubsubbeat
-git clone https://github.com/nugielim/gpubsubbeat
+mkdir -p ${GOPATH}/src/github.com/nugielim/gpubsubbeat
+cd ${GOPATH}/src/github.com/nugielim/gpubsubbeat
+git clone https://github.com/nugielim/gpubsubbeat .
 ```
 
 

--- a/config/config.go
+++ b/config/config.go
@@ -6,14 +6,17 @@ package config
 import "time"
 
 type Config struct {
-	Period      time.Duration `config:"period"`
-	ProjectID   string        `config:"projectid"`
-	MaxFetchMsg int           `config:"maxfetchmsg"`
-	Region      string        `config:"region"`
+	Period           time.Duration `config:"period"`
+	ProjectID        string        `config:"projectid"`
+	TopicName        string        `config:"topic_name"`
+	CreateTopic      bool          `config:"create_topic"`
+	SubscriberName   string        `config:"subscriber_name"`
+	SubscriberPrefix string        `config:"subscriber_prefix"`
 }
 
 var DefaultConfig = Config{
-	Period:      1 * time.Second,
-	ProjectID:   "env",
-	Region:      "us-central1",
+	Period:         1 * time.Second,
+	ProjectID:      "env",
+	TopicName:      "gpubsubbeat-all",
+	SubscriberName: "gpubsubbeat-subscription",
 }

--- a/gpubsubbeat.full.yml
+++ b/gpubsubbeat.full.yml
@@ -6,7 +6,10 @@ gpubsubbeat:
   # Defines how often an event is sent to the output
   period: 1s
   projectid: env
-  region: all
+  topic_name: gpubsubbeat-all
+  #create_topic: false
+  subscriber_name: gpubsubbeat-subscriber
+  #subscriber_prefix: gpubsubbeat-
 #================================ General ======================================
 
 # The name of the shipper that publishes the network data. It can be used to group

--- a/gpubsubbeat.yml
+++ b/gpubsubbeat.yml
@@ -6,7 +6,9 @@ gpubsubbeat:
   # Defines how often an event is sent to the output
   period: 1s
   projectid: env
-  region: all
+  topic_name: gpubsubbeat-all
+  subscriber_name: subscription
+
 #================================ General =====================================
 
 # The name of the shipper that publishes the network data. It can be used to group


### PR DESCRIPTION
This PR change gpubsubbeat in that way that is possible to run multiple beats in the same GCP project account, since the topic and subscriber names are not hard coded anymore.

To do that I introduced few new variables:
* topic_name - name on the topic to subscribe to
* create_topic - If topic doesn't exist create the topic
* subscriber_name - subscriber name. If it doens't exist create one
* subscriber_prefix - randomly generated subscriber name with the predefined prefix.

Improvements:
* Improve the message error if the subscriber already exists
* Verify if the subscriber pulls the data from the right topic
* minor structure code changes to simplify testing
* code formatting
* safety check for the payload, so if not well formatted the message get ignored

TODO:
* further code refactor to improve code testing
* refactor signal handling
* remove unused tickers